### PR TITLE
Changed yamlKey regex to match valid keys like www.google.com

### DIFF
--- a/yaml.vim
+++ b/yaml.vim
@@ -36,7 +36,7 @@ syn match   yamlAlias           "\*.\+"
 syn match   yamlDelimiter       "[-,:]"
 syn match   yamlBlock           "[\[\]\{\}>|]"
 syn match   yamlOperator        '[?+-]'
-syn match   yamlKey             '\w\+\(\s\+\w\+\)*\ze\s*:'
+syn match   yamlKey             '\(\.\|\w\)\+\(\s\+\(\.\|\w\)\+\)*\ze\s*:'
 syn match   yamlScalar          '\(\(|\|>\)\s*\n*\r*\)\@<=\(\s\+\).*\n*\r*\(\(\3\).*\n\)*'
 
 " Predefined data types


### PR DESCRIPTION
Hello

According to the [Yaml Reference Parser] [1] this document should be valid:

```
    www.google.com: yes
    www.yahoo.com: n
```

but vim syntax was failing to recognize '.' as valid. So I added it to the Regex that matches the yaml keys.

Thanks in advance

 [1]: http://yaml.org http://yaml.org/ypaste/
